### PR TITLE
updcheck: fix minor security issue; sync pkgdb

### DIFF
--- a/updcheck/lfsqol.toml
+++ b/updcheck/lfsqol.toml
@@ -93,14 +93,14 @@ source = "repology"
 repology = "pugixml"
 repo = "arch"
 
-[re2]
-source = "repology"
-repology = "re2"
-repo = "nix_unstable"
-
 [qrcodegencpp]
 source = "repology"
 repology = "qrcodegencpp"
+repo = "nix_unstable"
+
+[re2]
+source = "repology"
+repology = "re2"
 repo = "nix_unstable"
 
 [sdbus-cpp]
@@ -111,6 +111,11 @@ repo = "arch"
 [sdl2-net]
 source = "repology"
 repology = "sdl2-net"
+repo = "arch"
+
+[seatd]
+source = "repology"
+repology = "seatd"
 repo = "arch"
 
 [tllist]
@@ -532,4 +537,9 @@ repo = "arch"
 source = "repology"
 repology = "prismlauncher"
 repo = "alpine_edge"
+
+[openttd]
+source = "repology"
+repology = "openttd"
+repo = "t2"
 

--- a/updcheck/packagesent2toml.py
+++ b/updcheck/packagesent2toml.py
@@ -88,9 +88,11 @@ def parsexml(line):
 	# seal331 22/05/2025 21:50 MSK: LFS-QOL intentionally ships an older
 	# version of openjdk for compatibility with old Minecraft
 	# seal331 23/05/2025 4:39 MSK: and more Java stuff got added...
+	# seal331 10/06/2025 19:05 MSK: ditto...
 	if ('openjdk-major' == pkgname) or ('openjdk' == pkgname) or \
 			('openjdk-build' == pkgname) or ('java-major' == pkgname) or \
-			('java' == pkgname) or ('java-build' == pkgname):
+			('java' == pkgname) or ('java-build' == pkgname) or \
+			('jdk-modern' == pkgname):
 		return False
 
 	# seal331 22/05/2025 21:56 MSK: rofi-wayland is tied to upstream
@@ -331,6 +333,11 @@ use_latest_release = true
 	# seal331 03/06/2025 21:07 MSK: Arch has an outdated version of this
 	if ('m17n-db' == pkgname):
 		repo = 'debian_unstable'
+
+	# seal331 10/06/2025 19:15 MSK: Arch doesn't ship OpenTTD betas like we
+	# do
+	if ('openttd' == pkgname):
+		repo = 't2'
 
 	# seal331 22/05/2025 21:27 MSK: -minor stuff is usually nicer-looking
 	# Git commit abbreviations, we check the git stuff separately

--- a/updcheck/packagesent2toml.py
+++ b/updcheck/packagesent2toml.py
@@ -174,7 +174,6 @@ def parsexml(line):
 
 	# seal331 23/05/2025 1:28 MSK: prismlauncher has a different name on
 	# Repology's side and is not in Arch's official repos
-
 	if ('prism-launcher' == pkgname):
 		pkgname = 'prismlauncher'
 		repo = 'alpine_edge'
@@ -341,6 +340,13 @@ use_latest_release = true
 		return False
 
 	# SPECIAL CASING ENDS HERE
+
+	# maintainer note: I like getting the error messages when there's an
+	# unsanitized external entity, despite that executing random
+	# nonexistent commands such as "inxi-version"
+	if not MAINTAINER_MODE:
+		version = version.replace('&', '').replace(';', '')
+
 	return [repo, pkgname, version]
 
 if len(sys.argv) != 2:

--- a/updcheck/versions_book.json
+++ b/updcheck/versions_book.json
@@ -41,10 +41,10 @@
       "version": "1.3.18"
     },
     "eza": {
-      "version": "0.21.3"
+      "version": "0.21.4"
     },
     "fastfetch": {
-      "version": "2.43.0"
+      "version": "2.44.0"
     },
     "fcft": {
       "version": "3.3.1"
@@ -86,7 +86,7 @@
       "version": "2.01"
     },
     "glaze": {
-      "version": "5.3.0"
+      "version": "5.3.1"
     },
     "glu": {
       "version": "9.0.3"
@@ -185,7 +185,7 @@
       "version": "0.12.20"
     },
     "m17n-db": {
-      "version": "1.8.9"
+      "version": "1.8.10"
     },
     "m17n-lib": {
       "version": "1.8.5"
@@ -222,6 +222,9 @@
     },
     "obs-studio": {
       "version": "31.0.3"
+    },
+    "openttd": {
+      "version": "15.0-beta2"
     },
     "ostree": {
       "version": "2025.2"
@@ -261,6 +264,9 @@
     },
     "sdl2-net": {
       "version": "2.2.0"
+    },
+    "seatd": {
+      "version": "0.9.1"
     },
     "socat": {
       "version": "1.8.0.3"


### PR DESCRIPTION
This PR fixes a minor security issue (even if maintainer mode was disabled AKA "only check known packages", if a known package without a special case for it got its version number changed to something alike "1.0-&random-version;", during the "known version record" stage the command "random-version" would be executed in addition to the actual nvtake invocation which would record the version number) and syncs the pkgdb with latest SLFS.

Open to any changes/questions.